### PR TITLE
Update CircleCI setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,26 @@ jobs:
     <<: *node_14_defaults
     <<: *test_defaults
 
+  deploy:
+    <<: *node_12_defaults
+    steps:
+      - checkout
+      - run:
+          name: Setup NPM
+          command: bash .circleci/setup-npm
+      - restore_cache:
+          name: Restore yarn cache
+          key: yarn-{{ checksum "yarn-lock-cache.key" }}
+      - run:
+          name: Yarn install
+          command: yarn install
+      - run:
+          name: Build package
+          command: yarn build
+      - run:
+          name: Publish package
+          command: npm publish
+
 workflows:
   version: 2
   default:
@@ -99,3 +119,11 @@ workflows:
       - test-node-14:
           requires:
             - build-node-14
+  release:
+    jobs:
+      - deploy:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,101 @@
----
 version: 2
+
+global_defaults: &global_defaults
+  working_directory: ~/pear
+
+build_defaults: &build_defaults
+  steps:
+    - checkout
+    - run:
+        name: Create yarn cache key
+        command: cp yarn.lock yarn-lock-cache.key && node --version >> yarn-lock-cache.key
+    - restore_cache:
+        name: Restore yarn cache
+        key: yarn-{{ checksum "yarn-lock-cache.key" }}
+    - run:
+        name: Yarn install
+        command: yarn install
+    - save_cache:
+        name: Save yarn cache
+        key: yarn-{{ checksum "yarn-lock-cache.key" }}
+        paths:
+          - node_modules/
+
+test_defaults: &test_defaults
+  steps:
+    - checkout
+    - run:
+        name: Create yarn cache key
+        command: cp yarn.lock yarn-lock-cache.key && node --version >> yarn-lock-cache.key
+    - restore_cache:
+        name: Restore yarn cache
+        key: yarn-{{ checksum "yarn-lock-cache.key" }}
+    - run:
+        name: Yarn install
+        command: yarn install
+    - run:
+        name: Get version
+        command: ./bin/run --version
+    - run:
+        name: Show help
+        command: ./bin/run --help
+    - run:
+        name: Run tests
+        command: yarn test
+
+node_10_defaults: &node_10_defaults
+  <<: *global_defaults
+  docker:
+    - image: node:10.20.1
+
+node_12_defaults: &node_12_defaults
+  <<: *global_defaults
+  docker:
+    - image: node:12.16.2
+
+node_14_defaults: &node_14_defaults
+  <<: *global_defaults
+  docker:
+    - image: node:14.0.0
+
 jobs:
-  build-and-test:
-    docker:
-      - image: node:latest
-    working_directory: ~/pear
-    steps:
-      - checkout
+  build-node-10:
+    <<: *node_10_defaults
+    <<: *build_defaults
 
-      - restore_cache:
-          name: Restore yarn cache
-          key: yarn-{{ checksum "yarn.lock" }}
+  test-node-10:
+    <<: *node_10_defaults
+    <<: *test_defaults
 
-      - run:
-          name: Yarn install
-          command: yarn install
+  build-node-12:
+    <<: *node_12_defaults
+    <<: *build_defaults
 
-      - save_cache:
-          name: Save yarn cache
-          key: yarn-{{ checksum "yarn.lock" }}
-          paths:
-            - node_modules/
+  test-node-12:
+    <<: *node_12_defaults
+    <<: *test_defaults
 
-      - run:
-          name: Get version
-          command: ./bin/run --version
+  build-node-14:
+    <<: *node_14_defaults
+    <<: *build_defaults
 
-      - run:
-          name: Show help
-          command: ./bin/run --help
-
-      - run:
-          name: Run tests
-          command: yarn test
+  test-node-14:
+    <<: *node_14_defaults
+    <<: *test_defaults
 
 workflows:
   version: 2
-  pear:
+  default:
     jobs:
-      - build-and-test
+      - build-node-10
+      - build-node-12
+      - build-node-14
+      - test-node-10:
+          requires:
+            - build-node-10
+      - test-node-12:
+          requires:
+            - build-node-12
+      - test-node-14:
+          requires:
+            - build-node-14

--- a/.circleci/npmrc
+++ b/.circleci/npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=REPLACE_ME

--- a/.circleci/setup-npm
+++ b/.circleci/setup-npm
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+cp ./.circleci/npmrc ~/.npmrc
+sed -i "s/REPLACE_ME/${NPM_TOKEN}/g" ~/.npmrc


### PR DESCRIPTION
This PR is quite a bit of an upgrade to the CI setup for pear. I started by realizing that rather than test against latest node, it would be cool to test against the typical trio of:

* latest
* minus one
* minus two

That feels like pretty good coverage. Node is weird because the stable releases skip the odd numbers or something? Anyway, I've landed on 14, 12 and 10 as the versions.

Then, I also added the ability for CircleCI to publish the package based on what I've learned working on forty-time.