### PR TITLE
Use a single consistent name for project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# pear [![CircleCI][badge]][circleci]
+# Pear [![CircleCI][badge]][circleci]
 
 Credit where credit is due.
 
 ## Install
 
-Since pear is an NPM package, installation can be as easy as:
+Since Pear is an NPM package, installation can be as easy as:
 
 ```
 $ npm install --global @jonallured/pear
@@ -55,33 +55,37 @@ Now that we have a known author we can add them to what we're working on:
 $ pear current:add jonallured
 ```
 
-This sets us up to give credit in our commits to `jonallured`. 
+This sets us up to give credit in our commits to `jonallured`.
 
-Note: `pear` supports multiple authors, so you can add as many authors to your current pairing session as you want!
+Note: Pear supports multiple authors, so you can add as many authors to your
+current pairing session as you want!
 
 ## Credit current authors on a commit
 
-Once you've got author(s) in your current session, you can use Pear in a number of ways to credit authors on a commit. They basically boil down to these:
+Once you've got author(s) in your current session, you can use Pear in a number
+of ways to credit authors on a commit. They basically boil down to these:
 
 ### 1. Copy/paste trailer into commit message
 
-Generate a trailer for the current pair(s): 
+Generate a trailer for the current pair(s):
 
 ```
 $ pear current:trailer
 Co-authored-by: Jonathan Allured <jon.allured@gmail.com>
 ```
 
-Manually copy/paste that trailer into your commit message, and your pair(s) will get credit!
+Manually copy/paste that trailer into your commit message, and your pair(s) will
+get credit!
 
-### 2. Amend the current commit with `pear`
+### 2. Amend the current commit with Pear
 
 ```
 $ pear amend
 Commit message amended! 🍐
 ```
 
-This will magically update the most recent commit with a trailer for all authors in your current session! Your pair(s) get credit again 😎.
+This will magically update the most recent commit with a trailer for all authors
+in your current session! Your pair(s) get credit again 😎.
 
 ### 3. Automate commit trailers with a post-commit hook
 
@@ -89,7 +93,8 @@ The first two are more manual in case git hooks aren't your thing but hooks are
 super cool and can make you feel like a genius. Impress your friends and have
 the trailer added automatically!
 
-Configure the hook to call `pear amend`, and your pair(s) will get credit as soon as you commit!!
+Configure the hook to call `pear amend`, and your pair(s) will get credit as
+soon as you commit!!
 
 ## Cutting a new release
 


### PR DESCRIPTION
Over on #28 @pepopowitz pointed out that the README wasn't very consistent when referring to the project by name so this just cleans that up a bit.