### PR TITLE
docs: corrected yarn global add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Since Pear is an NPM package, installation can be as easy as:
 ```
 $ npm install --global @jonallured/pear
 // or
-$ yarn add global @jonallured/pear
+$ yarn global add @jonallured/pear
 ```
 
 Note that I've got this under a namespace so you have to specify that.


### PR DESCRIPTION
# Description

Running `yarn add global @jonallured/pear` resulted in installing locally `global` and `@jonallured/pear` packages.
Changed that to be `yarn global add @jonallured/pear` to have the expected behaviour (install globally the pear cli tool)

Here are the yarn docs for [yarn global <add/bin/list/remove/upgrade> [--prefix]](https://classic.yarnpkg.com/en/docs/cli/global/)