### PR TITLE
Output new list of current authors when adding to current

### DIFF
--- a/src/commands/current/add.ts
+++ b/src/commands/current/add.ts
@@ -13,6 +13,8 @@ export default class AddCurrent extends BaseCommand {
     try {
       const data = new PearData()
       await data.addCurrent(usernames)
+      const current = JSON.stringify(data.current, null, 2)
+      this.log(current)
       this.log(Pear.Messages.AddedCurrent)
     } catch (error) {
       this.handleError(error)


### PR DESCRIPTION
Co-authored-by: @jonallured 

Whenever I run `pear current:add`, I immediately run `pear current` to confirm that I added the correct author. This PR updates the `pear current:add` command to return the updated current authors so that I can type less.

No tests are included because who even cares about tests

<img width="686" alt="image" src="https://user-images.githubusercontent.com/1627089/167944995-18a14dc4-7d2d-4001-9cb4-327dd4b1f9f6.png">


