### PR TITLE
Remove duplicates from current

### DIFF
--- a/src/pear-data.ts
+++ b/src/pear-data.ts
@@ -55,7 +55,7 @@ export class PearData {
       usernames.includes(author.username),
     )
 
-    const current = this.current.concat(newCurrentAuthors)
+    const current = [...new Set(this.current.concat(newCurrentAuthors))]
     const json = { current, known: this.known }
     this.writeJson(json)
   }

--- a/test/pear-data.test.ts
+++ b/test/pear-data.test.ts
@@ -82,6 +82,25 @@ describe("pearData.addCurrent", () => {
     })
   })
 
+  describe("with duplicate known authors", () => {
+    it("does not add dupes to current", async () => {
+      const mockPrompt = jest.fn()
+      mockPrompt.mockReturnValueOnce(erik.name)
+      mockPrompt.mockReturnValueOnce(erik.email)
+      Pear.Utils.prompt = mockPrompt
+      const mockFileWrite = jest.fn()
+      Pear.Utils.writeFile = mockFileWrite
+
+      const path = "test/fixtures/two-known-authors"
+      const pearData = new PearData(path)
+
+      await pearData.addCurrent([erik.username])
+      await pearData.addCurrent([erik.username])
+
+      expect(pearData.current.length).toEqual(1)
+    })
+  })
+
   describe("with an unknown author", () => {
     it("adds a new known and current author", async () => {
       const mockPrompt = jest.fn()


### PR DESCRIPTION
This PR adds a test case for providing duplicate current users so we can remove them before writing to the data file.

Closes #16