### PR TITLE
Properly separate message from trailers

### DIFF
--- a/src/commands/amend.ts
+++ b/src/commands/amend.ts
@@ -30,7 +30,7 @@ export default class Amend extends BaseCommand {
 
     const trailers = data.trailer()
     const cleanedMessage = currentMessage.replace(/Co-authored-by[\s\S]*/g, "")
-    return cleanedMessage + trailers
+    return cleanedMessage + "\n\n" + trailers
   }
 
   private amendCommit(newMessage: string): void {


### PR DESCRIPTION
I'm pretty confused about why this used to work but then didn't and now this fixes it? Like if I didn't have enough newlines then shouldn't this have been an issue all along? And if I did have enough newlines at some point then what changed where now I don't?

Mysterous!

/cc @pvinis